### PR TITLE
Add installation steps for vim via plugin manager

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,20 @@ Copy the `.tmTheme` files to `~/Library/Application Support/TextMate/Themes`.
 
 ### Vim
 
+#### Vim-plug
+
+```vim
+Plug 'sindresorhus/focus', { 'rtp': 'vim' }
+```
+
+#### Vundle
+
+```vim
+Plugin 'sindresorhus/focus', {'rtp': 'vim/'}
+```
+
+#### Manual
+
 Copy the contents of the `vim/colors` folder to `~/.vim/colors`.
 
 ### Other editors

--- a/readme.md
+++ b/readme.md
@@ -43,13 +43,13 @@ Copy the `.tmTheme` files to `~/Library/Application Support/TextMate/Themes`.
 #### Vim-plug
 
 ```vim
-Plug 'sindresorhus/focus', { 'rtp': 'vim' }
+Plug 'sindresorhus/focus', {'rtp': 'vim'}
 ```
 
 #### Vundle
 
 ```vim
-Plugin 'sindresorhus/focus', {'rtp': 'vim/'}
+Plugin 'sindresorhus/focus', {'rtp': 'vim'}
 ```
 
 #### Manual


### PR DESCRIPTION
I just added installation steps for two popular vim plugins manager ([vim-plug](https://github.com/junegunn/vim-plug) and [vundle](https://github.com/VundleVim/Vundle.vim)), it's just for easy copy/paste to `.vimrc`/`init.vim` files.